### PR TITLE
Delete cookie properly

### DIFF
--- a/routes/api/logout.ts
+++ b/routes/api/logout.ts
@@ -4,7 +4,9 @@ export function handler(req: Request): Response {
   const headers = new Headers({
     "location": new URL(req.url).origin,
   });
-  deleteCookie(headers, "deploy_access_token");
+  deleteCookie(headers, "deploy_access_token", {
+    path: "/",
+  });
   return new Response(null, {
     status: 302,
     headers,

--- a/routes/api/logout.ts
+++ b/routes/api/logout.ts
@@ -4,7 +4,7 @@ export function handler(req: Request): Response {
   const headers = new Headers({
     "location": new URL(req.url).origin,
   });
-  deleteCookie(headers, "deploy_access_token", {
+  deleteCookie(headers, "deploy_chat_token", {
     path: "/",
   });
   return new Response(null, {


### PR DESCRIPTION
Fix: deploy_access_token wasn't deleted from the cookies after calling /api/logout